### PR TITLE
Remove unused import of options from RatingWidget.tsx to fix build

### DIFF
--- a/packages/mantine/src/widgets/RatingWidget.tsx
+++ b/packages/mantine/src/widgets/RatingWidget.tsx
@@ -23,7 +23,6 @@ export default function RatingWidget<T = any, S extends StrictRJSFSchema = RJSFS
     onChange,
     onChangeOverride,
     autofocus,
-    options,
     schema,
     rawErrors,
     hideError,


### PR DESCRIPTION
Remove unused import of options from ./packages/mantine/src/widgets/RatingWidget.tsx to fix build.

Failing build output:

```
tmeade@Timothys-MacBook-Pro rjsf-mantine-theme % ./node_modules/.bin/lerna run build
lerna notice cli v8.1.2

 Lerna (powered by Nx)   Running target build for 3 projects

   ✖  @aokiapp/rjsf-mantine-theme:build
      > @aokiapp/rjsf-mantine-theme@0.2.2 build
      > npm run build:ts && npm run build:bundle
      
      
      > @aokiapp/rjsf-mantine-theme@0.2.2 build:ts
      > tsc -b
      
      src/widgets/RatingWidget.tsx(26,5): error TS6133: 'options' is declared but its value is never read.
      npm ERR! Lifecycle script `build:ts` failed with error: 
      npm ERR! Error: command failed 
      npm ERR!   in workspace: @aokiapp/rjsf-mantine-theme@0.2.2 
      npm ERR!   at location: /Users/tmeade/src/projects/saas-base/site/app/appsub-config-panel/vendor/rjsf-mantine-theme/packages/mantine 
      npm ERR! Lifecycle script `build` failed with error: 
      npm ERR! Error: command failed 
      npm ERR!   in workspace: @aokiapp/rjsf-mantine-theme@0.2.2 
      npm ERR!   at location: /Users/tmeade/src/projects/saas-base/site/app/appsub-config-panel/vendor/rjsf-mantine-theme/packages/mantine 
      
      

——————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 Lerna (powered by Nx)   Ran target build for 3 projects (5s)

   ✔  0/1 succeeded [0 read from cache]

   ✖  1/1 targets failed, including the following:

      - @aokiapp/rjsf-mantine-theme:build

tmeade@Timothys-MacBook-Pro rjsf-mantine-theme % 
```