### PR TITLE
Replace Select component with NativeSelect component

### DIFF
--- a/packages/mantine/src/widgets/SelectWidget.tsx
+++ b/packages/mantine/src/widgets/SelectWidget.tsx
@@ -9,7 +9,7 @@ import {
   StrictRJSFSchema,
   WidgetProps,
 } from '@rjsf/utils';
-import { MultiSelect, Select } from '@mantine/core';
+import { MultiSelect, NativeSelect } from '@mantine/core';
 import { createErrors } from '../utils/createErrors';
 import { useFieldContext } from '../templates/FieldTemplate';
 
@@ -84,10 +84,7 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
     );
   } else {
     return (
-      <Select
-        allowDeselect
-        checkIconPosition='right'
-        clearable={!required}
+      <NativeSelect
         data={(enumOptions || []).map(({ value, label }, i) => {
           const disabled = enumDisabled && enumDisabled.indexOf(value) !== -1;
           return { value: String(i), label, disabled };
@@ -98,11 +95,8 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
         label={labelValue(label, hideLabel, false)}
         autoFocus={autofocus}
         required={required}
-        searchable
         value={selectedIndices as string | null}
-        onChange={handleChange}
-        onDropdownClose={handleBlur}
-        onDropdownOpen={handleFocus}
+        onChange={(event) => handleChange(event.currentTarget.value)}
         aria-describedby={ariaDescribedByIds<T>(id)}
         placeholder={placeholder}
         className='armt-widget-select armt-widget-select-single'

--- a/packages/mantine/src/widgets/SelectWidget.tsx
+++ b/packages/mantine/src/widgets/SelectWidget.tsx
@@ -83,22 +83,23 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
       />
     );
   } else {
+    const valuedData = (enumOptions || []).map(({ value, label }, i) => {
+      const disabled = enumDisabled && enumDisabled.indexOf(value) !== -1;
+      return { value: String(i), label, disabled };
+    });
+    const data = [{ value: '-1', label: placeholder || '' }, ...valuedData];
     return (
       <NativeSelect
-        data={(enumOptions || []).map(({ value, label }, i) => {
-          const disabled = enumDisabled && enumDisabled.indexOf(value) !== -1;
-          return { value: String(i), label, disabled };
-        })}
+        data={data}
         description={description}
         disabled={disabled || readonly}
         error={createErrors<T>(rawErrors, hideError)}
         label={labelValue(label, hideLabel, false)}
         autoFocus={autofocus}
         required={required}
-        value={selectedIndices as string | null}
+        value={selectedIndices ?? '-1'}
         onChange={(event) => handleChange(event.currentTarget.value)}
         aria-describedby={ariaDescribedByIds<T>(id)}
-        placeholder={placeholder}
         className='armt-widget-select armt-widget-select-single'
       />
     );

--- a/packages/mantine/src/widgets/SelectWidget.tsx
+++ b/packages/mantine/src/widgets/SelectWidget.tsx
@@ -99,6 +99,8 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
         required={required}
         value={selectedIndices ?? '-1'}
         onChange={(event) => handleChange(event.currentTarget.value)}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         aria-describedby={ariaDescribedByIds<T>(id)}
         className='armt-widget-select armt-widget-select-single'
       />


### PR DESCRIPTION
Fixes #26

Replace the `Select` component with the `NativeSelect` component in `SelectWidget.tsx`.

* **Import Statement**
  - Update import statement to import `NativeSelect` from `@mantine/core`.

* **Component Replacement**
  - Replace `Select` component with `NativeSelect` component.
  - Adjust the `handleChange` function to handle the `NativeSelect` value.

* **Remove Unnecessary Props**
  - Remove `searchable`, `onDropdownClose`, and `onDropdownOpen` props from `NativeSelect`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AokiApp/rjsf-mantine-theme/issues/26?shareId=9bbe0344-4621-44ad-a407-01c3a26a86ec).